### PR TITLE
fixes a possible out or range error

### DIFF
--- a/BetterChinookPatrol.cs
+++ b/BetterChinookPatrol.cs
@@ -73,6 +73,9 @@ namespace Oxide.Plugins
             if (ch47.ShouldLand())
                 return;
 
+            if (_eligiblePatrolPoints.Count < 1)
+                return;
+
             var brain = ch47.GetComponent<CH47AIBrain>();
             if (brain == null)
                 return;


### PR DESCRIPTION
in the rare event this ever happens:

[Better Chinook Patrol] 0 monuments on this map may be visited by Chinooks. 0 have drop zones.